### PR TITLE
Clear inTag when shifting XML

### DIFF
--- a/html/lex.go
+++ b/html/lex.go
@@ -459,6 +459,7 @@ func (l *Lexer) shiftXml(rawTag Hash) []byte {
 		c := l.r.Peek(0)
 		if c == '>' {
 			l.r.Move(1)
+			l.inTag = false
 			break
 		} else if c == 0 {
 			break


### PR DESCRIPTION
Fixes tdewolff/minify/issues/119

Figure this is the best way to address the issue. Open to suggestions if the resolution is crude.

Not sure if you want to add a regression test but the following would add coverage in html/lex_test.go:
```go
{"<a><svg>text</svg></a>", TTs{StartTagToken, StartTagCloseToken, SvgToken, EndTagToken}},
```