### PR TITLE
Fix regexp following a keyword

### DIFF
--- a/js/lex.go
+++ b/js/lex.go
@@ -162,8 +162,19 @@ func (l *Lexer) Next() (TokenType, []byte) {
 	if tt == LineTerminatorToken || tt == PunctuatorToken && regexpStateByte[c] {
 		l.regexpState = true
 	} else if tt == IdentifierToken {
-		hash := ToHash(l.r.Lexeme())
-		l.regexpState = hash != 0 && hash != This
+		switch hash := ToHash(l.r.Lexeme()); hash {
+		case 0: // Custom identifier
+		case This:
+		case False:
+		case True:
+		case Null:
+			l.regexpState = false
+		default:
+			// This will include keywords that can't be followed by a regexp, but only
+			// by a specified char (like `if` or `try`), but we don't check for syntax
+			// errors as we don't attempt to parse a full JS grammar when streaming
+			l.regexpState = true
+		}
 	} else {
 		l.regexpState = false
 	}

--- a/js/lex.go
+++ b/js/lex.go
@@ -161,6 +161,9 @@ func (l *Lexer) Next() (TokenType, []byte) {
 	// ErrorToken, WhitespaceToken and CommentToken are already returned
 	if tt == LineTerminatorToken || tt == PunctuatorToken && regexpStateByte[c] {
 		l.regexpState = true
+	} else if tt == IdentifierToken {
+		hash := ToHash(l.r.Lexeme())
+		l.regexpState = hash != 0 && hash != This
 	} else {
 		l.regexpState = false
 	}

--- a/js/lex_test.go
+++ b/js/lex_test.go
@@ -100,6 +100,9 @@ func TestTokens(t *testing.T) {
 		{"a=/x/\u200C\u3009", TTs{IdentifierToken, PunctuatorToken, RegexpToken, UnknownToken}},
 		{"a=/x\n", TTs{IdentifierToken, PunctuatorToken, PunctuatorToken, IdentifierToken, LineTerminatorToken}},
 
+		{"return /abc/;", TTs{IdentifierToken, RegexpToken, PunctuatorToken}},
+		{"yield /abc/;", TTs{IdentifierToken, RegexpToken, PunctuatorToken}},
+
 		// go fuzz
 		{"`", TTs{UnknownToken}},
 	}


### PR DESCRIPTION
This reflects similar rule to what Acorn and Esprima use in JS parsing world - if you see a keyword, and it's not `this`, it can be followed only by either regular expression or be a syntax error (we don't check the latter).

This might still run into edge cases such as `yield` being an identifier in legacy code, in which case it has to be followed by division, but, as with any contextual keywords, this would require more complexity.

See https://github.com/tdewolff/minify/issues/132 for the impact of this change.

Partially covers #16.