### PR TITLE
Add support for HTML-style line comments

### DIFF
--- a/js/lex.go
+++ b/js/lex.go
@@ -70,12 +70,14 @@ type Lexer struct {
 
 	regexpState   bool
 	templateState bool
+	emptyLine     bool
 }
 
 // NewLexer returns a new Lexer for a given io.Reader.
 func NewLexer(r io.Reader) *Lexer {
 	return &Lexer{
-		r: buffer.NewLexer(r),
+		r:         buffer.NewLexer(r),
+		emptyLine: true,
 	}
 }
 
@@ -102,7 +104,9 @@ func (l *Lexer) Next() (TokenType, []byte) {
 			tt = PunctuatorToken
 		}
 	case '<', '>', '=', '!', '+', '-', '*', '%', '&', '|', '^':
-		if l.consumeLongPunctuatorToken() {
+		if (c == '<' || (l.emptyLine && c == '-')) && l.consumeCommentToken() {
+			return CommentToken, l.r.Shift()
+		} else if l.consumeLongPunctuatorToken() {
 			tt = PunctuatorToken
 		}
 	case '/':
@@ -156,6 +160,8 @@ func (l *Lexer) Next() (TokenType, []byte) {
 			return ErrorToken, nil
 		}
 	}
+
+	l.emptyLine = tt == LineTerminatorToken
 
 	// differentiate between divisor and regexp state, because the '/' character is ambiguous!
 	// ErrorToken, WhitespaceToken and CommentToken are already returned
@@ -285,39 +291,55 @@ func (l *Lexer) consumeUnicodeEscape() bool {
 
 ////////////////////////////////////////////////////////////////
 
-func (l *Lexer) consumeCommentToken() bool {
-	if l.r.Peek(0) != '/' || l.r.Peek(1) != '/' && l.r.Peek(1) != '*' {
-		return false
-	}
-	if l.r.Peek(1) == '/' {
-		l.r.Move(2)
-		// single line
-		for {
-			c := l.r.Peek(0)
-			if c == '\r' || c == '\n' || c == 0 {
+func (l *Lexer) consumeSingleLineToken(skip int) {
+	l.r.Move(skip)
+	for {
+		c := l.r.Peek(0)
+		if c == '\r' || c == '\n' || c == 0 {
+			break
+		} else if c >= 0xC0 {
+			mark := l.r.Pos()
+			if r, _ := l.r.PeekRune(0); r == '\u2028' || r == '\u2029' {
+				l.r.Rewind(mark)
 				break
-			} else if c >= 0xC0 {
-				mark := l.r.Pos()
-				if r, _ := l.r.PeekRune(0); r == '\u2028' || r == '\u2029' {
-					l.r.Rewind(mark)
+			}
+		}
+		l.r.Move(1)
+	}
+}
+
+func (l *Lexer) consumeCommentToken() bool {
+	c := l.r.Peek(0)
+	if c == '/' {
+		c = l.r.Peek(1)
+		if c == '/' {
+			// single line
+			l.consumeSingleLineToken(2)
+		} else if c == '*' {
+			l.r.Move(2)
+			// multi line
+			for {
+				c := l.r.Peek(0)
+				if c == '*' && l.r.Peek(1) == '/' {
+					l.r.Move(2)
+					return true
+				} else if c == 0 {
 					break
 				}
+				l.r.Move(1)
 			}
-			l.r.Move(1)
+		} else {
+			return false
 		}
+	} else if c == '<' && l.r.Peek(1) == '!' && l.r.Peek(2) == '-' && l.r.Peek(3) == '-' {
+		// opening HTML-style single line comment
+		l.consumeSingleLineToken(4)
+	} else if c == '-' && l.r.Peek(1) == '-' && l.r.Peek(2) == '>' {
+		// closing HTML-style single line comment
+		// (only if current line didn't contain any meaningful tokens)
+		l.consumeSingleLineToken(3)
 	} else {
-		l.r.Move(2)
-		// multi line
-		for {
-			c := l.r.Peek(0)
-			if c == '*' && l.r.Peek(1) == '/' {
-				l.r.Move(2)
-				return true
-			} else if c == 0 {
-				break
-			}
-			l.r.Move(1)
-		}
+		return false
 	}
 	return true
 }

--- a/js/lex_test.go
+++ b/js/lex_test.go
@@ -56,6 +56,10 @@ func TestTokens(t *testing.T) {
 		{"a = /.*/g;", TTs{IdentifierToken, PunctuatorToken, RegexpToken, PunctuatorToken}},
 
 		{"/*co\nm\u2028m/*ent*/ //co//mment\u2029//comment", TTs{CommentToken, CommentToken, LineTerminatorToken, CommentToken}},
+		{"<!-", TTs{PunctuatorToken, PunctuatorToken, PunctuatorToken}},
+		{"1<!--2\n", TTs{NumericToken, CommentToken, LineTerminatorToken}},
+		{"x=y-->10\n", TTs{IdentifierToken, PunctuatorToken, IdentifierToken, PunctuatorToken, PunctuatorToken, NumericToken, LineTerminatorToken}},
+		{"  /*comment*/ -->nothing\n", TTs{CommentToken, CommentToken, LineTerminatorToken}},
 		{"$ _\u200C \\u2000 \u200C", TTs{IdentifierToken, IdentifierToken, IdentifierToken, UnknownToken}},
 		{">>>=>>>>=", TTs{PunctuatorToken, PunctuatorToken, PunctuatorToken}},
 		{"/", TTs{PunctuatorToken}},


### PR DESCRIPTION
These are weird, but they're part of ES2015 spec for backward compatibility and are actually met in the wild.

Ref: https://www.ecma-international.org/ecma-262/6.0/#sec-html-like-comments