### PR TITLE
Change Lexer to MemLexer + some fixes

### DIFF
--- a/css/lex.go
+++ b/css/lex.go
@@ -140,13 +140,13 @@ func (tt TokenType) String() string {
 
 // Lexer is the state for the lexer.
 type Lexer struct {
-	r *buffer.Lexer
+	r *buffer.MemLexer
 }
 
 // NewLexer returns a new Lexer for a given io.Reader.
 func NewLexer(r io.Reader) *Lexer {
 	return &Lexer{
-		buffer.NewLexer(r),
+		buffer.NewMemLexer(r),
 	}
 }
 

--- a/css/util.go
+++ b/css/util.go
@@ -1,11 +1,14 @@
 package css // import "github.com/tdewolff/parse/css"
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // IsIdent returns true if the bytes are a valid identifier.
 func IsIdent(b []byte) bool {
 	l := NewLexer(bytes.NewBuffer(b))
 	l.consumeIdentToken()
+	l.r.Restore()
 	return l.r.Pos() == len(b)
 }
 
@@ -13,6 +16,7 @@ func IsIdent(b []byte) bool {
 func IsURLUnquoted(b []byte) bool {
 	l := NewLexer(bytes.NewBuffer(b))
 	l.consumeUnquotedURL()
+	l.r.Restore()
 	return l.r.Pos() == len(b)
 }
 

--- a/html/lex.go
+++ b/html/lex.go
@@ -66,7 +66,7 @@ func (tt TokenType) String() string {
 
 // Lexer is the state for the lexer.
 type Lexer struct {
-	r   *buffer.Lexer
+	r   *buffer.MemLexer
 	err error
 
 	rawTag Hash
@@ -79,7 +79,7 @@ type Lexer struct {
 // NewLexer returns a new Lexer for a given io.Reader.
 func NewLexer(r io.Reader) *Lexer {
 	return &Lexer{
-		r: buffer.NewLexer(r),
+		r: buffer.NewMemLexer(r),
 	}
 }
 

--- a/js/lex.go
+++ b/js/lex.go
@@ -90,7 +90,7 @@ func (tt TokenType) String() string {
 
 // Lexer is the state for the lexer.
 type Lexer struct {
-	r         *buffer.Lexer
+	r         *buffer.MemLexer
 	stack     []ParsingContext
 	state     TokenState
 	emptyLine bool
@@ -99,7 +99,7 @@ type Lexer struct {
 // NewLexer returns a new Lexer for a given io.Reader.
 func NewLexer(r io.Reader) *Lexer {
 	return &Lexer{
-		r:         buffer.NewLexer(r),
+		r:         buffer.NewMemLexer(r),
 		stack:     make([]ParsingContext, 0),
 		state:     ExprState,
 		emptyLine: true,

--- a/json/parse.go
+++ b/json/parse.go
@@ -102,7 +102,7 @@ func (state State) String() string {
 
 // Parser is the state for the lexer.
 type Parser struct {
-	r     *buffer.Lexer
+	r     *buffer.MemLexer
 	state []State
 	err   error
 
@@ -112,7 +112,7 @@ type Parser struct {
 // NewParser returns a new Parser for a given io.Reader.
 func NewParser(r io.Reader) *Parser {
 	return &Parser{
-		r:     buffer.NewLexer(r),
+		r:     buffer.NewMemLexer(r),
 		state: []State{ValueState},
 	}
 }
@@ -306,7 +306,7 @@ func (p *Parser) consumeStringToken() bool {
 		if c == '"' {
 			p.r.Move(1)
 			break
-		} else if c == '\\' && (p.r.Peek(1) != 0 || p.r.Err() == nil) {
+		} else if c == '\\' && (p.r.Peek(1) != 0 /* || p.r.Err() == nil */) {
 			p.r.Move(1)
 		} else if c == 0 {
 			return false

--- a/xml/lex.go
+++ b/xml/lex.go
@@ -68,7 +68,7 @@ func (tt TokenType) String() string {
 
 // Lexer is the state for the lexer.
 type Lexer struct {
-	r   *buffer.Lexer
+	r   *buffer.MemLexer
 	err error
 
 	inTag bool
@@ -80,7 +80,7 @@ type Lexer struct {
 // NewLexer returns a new Lexer for a given io.Reader.
 func NewLexer(r io.Reader) *Lexer {
 	return &Lexer{
-		r: buffer.NewLexer(r),
+		r: buffer.NewMemLexer(r),
 	}
 }
 


### PR DESCRIPTION
Initial test seems to increase speed significantly, see table below. Some refactoring is required between `buffer` and `parse`, specifically in how to efficiently handle terminating buffers with NULL. See tdewolff/minify/#156.