### PR TITLE
CSS: skip parse errors in colon position

### DIFF
--- a/css/parse.go
+++ b/css/parse.go
@@ -353,16 +353,23 @@ func (p *Parser) parseQualifiedRuleDeclarationList() GrammarType {
 func (p *Parser) parseDeclaration() GrammarType {
 	p.initBuf()
 	parse.ToLower(p.data)
-	if tt, _ := p.popToken(false); tt != ColonToken {
-		p.err = parse.NewErrorLexer("unexpected token in declaration", p.l.r)
-		return ErrorGrammar
-	}
 	skipWS := true
+	first := true
+	grammar := DeclarationGrammar
 	for {
 		tt, data := p.popToken(false)
+		if first {
+			first = false
+			if tt == ColonToken {
+				continue
+			}
+			skipWS = false
+			p.err = parse.NewErrorLexer("unexpected token in declaration", p.l.r)
+			grammar = ErrorGrammar
+		}
 		if (tt == SemicolonToken || tt == RightBraceToken) && p.level == 0 || tt == ErrorToken {
 			p.prevEnd = (tt == RightBraceToken)
-			return DeclarationGrammar
+			return grammar
 		} else if tt == LeftParenthesisToken || tt == LeftBraceToken || tt == LeftBracketToken || tt == FunctionToken {
 			p.level++
 		} else if tt == RightParenthesisToken || tt == RightBraceToken || tt == RightBracketToken {

--- a/css/parse_test.go
+++ b/css/parse_test.go
@@ -91,6 +91,9 @@ func TestParse(t *testing.T) {
 		{false, ".foo { *color: #fff;}", ".foo{*color:#fff;}"},
 		{true, "*color: red; font-size: 12pt;", "*color:red;font-size:12pt;"},
 		{true, "_color: red; font-size: 12pt;", "_color:red;font-size:12pt;"},
+		{false, ".foo { baddecl } .bar { font-size: 12pt; }", ".foo{baddecl;}.bar{font-size:12pt;}"},
+		{false, ".foo { baddecl baddecl2 baddecl3; height: 200px } .bar { font-size: 12pt; }", ".foo{baddecl baddecl2 baddecl3;height:200px;}.bar{font-size:12pt;}"},
+		{false, ".foo { visibility: hidden;” } .bar { color: red }", ".foo{visibility:hidden;”;}.bar{color:red;}"},
 
 		// issues
 		{false, "@media print {.class{width:5px;}}", "@media print{.class{width:5px;}}"},                  // #6


### PR DESCRIPTION
If colon was expected, but found something else, that token should be still processed as per other rules to correctly close the block etc.

Fixes tdewolff/minify#206