### PR TITLE
Fix no colon

### DIFF
--- a/css/parse.go
+++ b/css/parse.go
@@ -353,8 +353,14 @@ func (p *Parser) parseQualifiedRuleDeclarationList() GrammarType {
 func (p *Parser) parseDeclaration() GrammarType {
 	p.initBuf()
 	parse.ToLower(p.data)
-	if tt, _ := p.popToken(false); tt != ColonToken {
+	if tt, data := p.popToken(false); tt != ColonToken {
+		for tt != SemicolonToken && tt != RightBraceToken && tt != ErrorToken {
+			p.pushBuf(WhitespaceToken, wsBytes)
+			p.pushBuf(tt, data)
+			tt, data = p.popToken(false)
+		}
 		p.err = parse.NewErrorLexer("unexpected token in declaration", p.l.r)
+		p.prevEnd = (tt == RightBraceToken)
 		return ErrorGrammar
 	}
 	skipWS := true

--- a/css/parse_test.go
+++ b/css/parse_test.go
@@ -91,6 +91,9 @@ func TestParse(t *testing.T) {
 		{false, ".foo { *color: #fff;}", ".foo{*color:#fff;}"},
 		{true, "*color: red; font-size: 12pt;", "*color:red;font-size:12pt;"},
 		{true, "_color: red; font-size: 12pt;", "_color:red;font-size:12pt;"},
+		{false, ".foo { baddecl } .bar { color:red; }", ".foo{baddecl;}.bar{color:red;}"},
+		{false, ".foo { baddecl baddecl baddecl; height:100px } .bar { color:red; }", ".foo{baddecl baddecl baddecl;height:100px;}.bar{color:red;}"},
+		{false, ".foo { visibility: hidden;” } .bar { color:red; }", ".foo{visibility:hidden;”;}.bar{color:red;}"},
 
 		// issues
 		{false, "@media print {.class{width:5px;}}", "@media print{.class{width:5px;}}"},                  // #6


### PR DESCRIPTION
@RReverser I think this is a better solution than #34, as it adds the proper semicolons also after faulty declarations. Can you please check?

Thanks for the reporting/PR though!