### PR TITLE
remove import comments

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -5,7 +5,7 @@ The `Reader` and `Writer` types implement the `io.Reader` and `io.Writer` respec
 The `Lexer` type is useful for building lexers because it keeps track of the start and end position of a byte selection, and shifts the bytes whenever a valid token is found.
 The `StreamLexer` does the same, but keeps a buffer pool so that it reads a limited amount at a time, allowing to parse from streaming sources.
 */
-package buffer // import "github.com/tdewolff/parse/buffer"
+package buffer
 
 // defaultBufSize specifies the default initial length of internal buffers.
 var defaultBufSize = 4096

--- a/buffer/lexer.go
+++ b/buffer/lexer.go
@@ -1,4 +1,4 @@
-package buffer // import "github.com/tdewolff/parse/buffer"
+package buffer
 
 import (
 	"io"

--- a/buffer/lexer_test.go
+++ b/buffer/lexer_test.go
@@ -1,4 +1,4 @@
-package buffer // import "github.com/tdewolff/parse/buffer"
+package buffer
 
 import (
 	"bytes"

--- a/buffer/reader.go
+++ b/buffer/reader.go
@@ -1,4 +1,4 @@
-package buffer // import "github.com/tdewolff/parse/buffer"
+package buffer
 
 import "io"
 

--- a/buffer/reader_test.go
+++ b/buffer/reader_test.go
@@ -1,4 +1,4 @@
-package buffer // import "github.com/tdewolff/parse/buffer"
+package buffer
 
 import (
 	"bytes"

--- a/buffer/streamlexer.go
+++ b/buffer/streamlexer.go
@@ -1,4 +1,4 @@
-package buffer // import "github.com/tdewolff/parse/buffer"
+package buffer
 
 import (
 	"io"

--- a/buffer/streamlexer_test.go
+++ b/buffer/streamlexer_test.go
@@ -1,4 +1,4 @@
-package buffer // import "github.com/tdewolff/parse/buffer"
+package buffer
 
 import (
 	"bytes"

--- a/buffer/writer.go
+++ b/buffer/writer.go
@@ -1,4 +1,4 @@
-package buffer // import "github.com/tdewolff/parse/buffer"
+package buffer
 
 // Writer implements an io.Writer over a byte slice.
 type Writer struct {

--- a/buffer/writer_test.go
+++ b/buffer/writer_test.go
@@ -1,4 +1,4 @@
-package buffer // import "github.com/tdewolff/parse/buffer"
+package buffer
 
 import (
 	"fmt"

--- a/common.go
+++ b/common.go
@@ -1,5 +1,5 @@
 // Package parse contains a collection of parsers for various formats in its subpackages.
-package parse // import "github.com/tdewolff/parse"
+package parse
 
 import (
 	"bytes"

--- a/common_test.go
+++ b/common_test.go
@@ -1,4 +1,4 @@
-package parse // import "github.com/tdewolff/parse"
+package parse
 
 import (
 	"encoding/base64"

--- a/css/hash_test.go
+++ b/css/hash_test.go
@@ -1,4 +1,4 @@
-package css // import "github.com/tdewolff/parse/css"
+package css
 
 import (
 	"testing"

--- a/css/lex.go
+++ b/css/lex.go
@@ -1,5 +1,5 @@
 // Package css is a CSS3 lexer and parser following the specifications at http://www.w3.org/TR/css-syntax-3/.
-package css // import "github.com/tdewolff/parse/css"
+package css
 
 // TODO: \uFFFD replacement character for NULL bytes in strings for example, or atleast don't end the string early
 

--- a/css/lex_test.go
+++ b/css/lex_test.go
@@ -1,4 +1,4 @@
-package css // import "github.com/tdewolff/parse/css"
+package css
 
 import (
 	"bytes"

--- a/css/parse.go
+++ b/css/parse.go
@@ -1,4 +1,4 @@
-package css // import "github.com/tdewolff/parse/css"
+package css
 
 import (
 	"bytes"

--- a/css/parse_test.go
+++ b/css/parse_test.go
@@ -1,4 +1,4 @@
-package css // import "github.com/tdewolff/parse/css"
+package css
 
 import (
 	"bytes"

--- a/css/util.go
+++ b/css/util.go
@@ -1,4 +1,4 @@
-package css // import "github.com/tdewolff/parse/css"
+package css
 
 import "github.com/tdewolff/parse/v2/buffer"
 

--- a/css/util_test.go
+++ b/css/util_test.go
@@ -1,4 +1,4 @@
-package css // import "github.com/tdewolff/parse/css"
+package css
 
 import (
 	"testing"

--- a/html/hash_test.go
+++ b/html/hash_test.go
@@ -1,4 +1,4 @@
-package html // import "github.com/tdewolff/parse/html"
+package html
 
 import (
 	"bytes"

--- a/html/lex.go
+++ b/html/lex.go
@@ -1,5 +1,5 @@
 // Package html is an HTML5 lexer following the specifications at http://www.w3.org/TR/html5/syntax.html.
-package html // import "github.com/tdewolff/parse/html"
+package html
 
 import (
 	"io"

--- a/html/lex_test.go
+++ b/html/lex_test.go
@@ -1,4 +1,4 @@
-package html // import "github.com/tdewolff/parse/html"
+package html
 
 import (
 	"bytes"

--- a/html/util.go
+++ b/html/util.go
@@ -1,4 +1,4 @@
-package html // import "github.com/tdewolff/parse/html"
+package html
 
 import "github.com/tdewolff/parse/v2"
 

--- a/html/util_test.go
+++ b/html/util_test.go
@@ -1,4 +1,4 @@
-package html // import "github.com/tdewolff/parse/html"
+package html
 
 import (
 	"testing"

--- a/js/hash_test.go
+++ b/js/hash_test.go
@@ -1,4 +1,4 @@
-package js // import "github.com/tdewolff/parse/js"
+package js
 
 import (
 	"testing"

--- a/js/lex.go
+++ b/js/lex.go
@@ -1,5 +1,5 @@
 // Package js is an ECMAScript5.1 lexer following the specifications at http://www.ecma-international.org/ecma-262/5.1/.
-package js // import "github.com/tdewolff/parse/js"
+package js
 
 import (
 	"io"

--- a/js/lex_test.go
+++ b/js/lex_test.go
@@ -1,4 +1,4 @@
-package js // import "github.com/tdewolff/parse/js"
+package js
 
 import (
 	"bytes"

--- a/json/parse.go
+++ b/json/parse.go
@@ -1,5 +1,5 @@
 // Package json is a JSON parser following the specifications at http://json.org/.
-package json // import "github.com/tdewolff/parse/json"
+package json
 
 import (
 	"io"

--- a/json/parse_test.go
+++ b/json/parse_test.go
@@ -1,4 +1,4 @@
-package json // import "github.com/tdewolff/parse/json"
+package json
 
 import (
 	"bytes"

--- a/strconv/float.go
+++ b/strconv/float.go
@@ -1,4 +1,4 @@
-package strconv // import "github.com/tdewolff/parse/strconv"
+package strconv
 
 import "math"
 

--- a/strconv/float_test.go
+++ b/strconv/float_test.go
@@ -1,4 +1,4 @@
-package strconv // import "github.com/tdewolff/parse/strconv"
+package strconv
 
 import (
 	"fmt"

--- a/strconv/int.go
+++ b/strconv/int.go
@@ -1,4 +1,4 @@
-package strconv // import "github.com/tdewolff/parse/strconv"
+package strconv
 
 import (
 	"math"

--- a/strconv/int_test.go
+++ b/strconv/int_test.go
@@ -1,4 +1,4 @@
-package strconv // import "github.com/tdewolff/parse/strconv"
+package strconv
 
 import (
 	"math"

--- a/strconv/price_test.go
+++ b/strconv/price_test.go
@@ -1,4 +1,4 @@
-package strconv // import "github.com/tdewolff/parse/strconv"
+package strconv
 
 import (
 	"testing"

--- a/svg/hash_test.go
+++ b/svg/hash_test.go
@@ -1,4 +1,4 @@
-package svg // import "github.com/tdewolff/parse/svg"
+package svg
 
 import (
 	"testing"

--- a/util.go
+++ b/util.go
@@ -1,4 +1,4 @@
-package parse // import "github.com/tdewolff/parse"
+package parse
 
 // Copy returns a copy of the given byte slice.
 func Copy(src []byte) (dst []byte) {

--- a/util_test.go
+++ b/util_test.go
@@ -1,4 +1,4 @@
-package parse // import "github.com/tdewolff/parse"
+package parse
 
 import (
 	"bytes"

--- a/xml/lex.go
+++ b/xml/lex.go
@@ -1,5 +1,5 @@
 // Package xml is an XML1.0 lexer following the specifications at http://www.w3.org/TR/xml/.
-package xml // import "github.com/tdewolff/parse/xml"
+package xml
 
 import (
 	"io"

--- a/xml/lex_test.go
+++ b/xml/lex_test.go
@@ -1,4 +1,4 @@
-package xml // import "github.com/tdewolff/parse/xml"
+package xml
 
 import (
 	"bytes"

--- a/xml/util.go
+++ b/xml/util.go
@@ -1,4 +1,4 @@
-package xml // import "github.com/tdewolff/parse/xml"
+package xml
 
 import "github.com/tdewolff/parse/v2"
 

--- a/xml/util_test.go
+++ b/xml/util_test.go
@@ -1,4 +1,4 @@
-package xml // import "github.com/tdewolff/parse/xml"
+package xml
 
 import (
 	"testing"


### PR DESCRIPTION
The import comments prevent the Go module compatibility code
from working, because they stop the module being imported
as its correct import path, `github.com/tdewolff/parse/v2`.

The `go.mod` file supercedes the need for import comments now anyway.