### PR TITLE
JS: Fixed panics in AST walker

### DIFF
--- a/js/ast.go
+++ b/js/ast.go
@@ -788,10 +788,6 @@ func (alias Alias) JS() string {
 	return alias.String()
 }
 
-func (alias *Alias) isNil() bool {
-	return alias == nil
-}
-
 // ImportStmt is an import statement.
 type ImportStmt struct {
 	List    []Alias

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -219,7 +219,7 @@ func TestJSRealWorldJS(t *testing.T) {
 
 	// reparse to make sure JS is still valid
 	_, err = Parse(parse.NewInputString(ast.JS()))
-	if err != nil && err == io.EOF {
+	if err != nil {
 		t.Error("Err: ", err)
 	}
 }

--- a/js/walk.go
+++ b/js/walk.go
@@ -46,16 +46,25 @@ func Walk(v IVisitor, n INode) {
 		Walk(v, n.Body)
 		Walk(v, n.Cond)
 	case *ForStmt:
-		Walk(v, n.Body)
+		if n.Body != nil {
+			Walk(v, n.Body)
+		}
+
 		Walk(v, n.Init)
 		Walk(v, n.Cond)
 		Walk(v, n.Post)
 	case *ForInStmt:
-		Walk(v, n.Body)
+		if n.Body != nil {
+			Walk(v, n.Body)
+		}
+
 		Walk(v, n.Init)
 		Walk(v, n.Value)
 	case *ForOfStmt:
-		Walk(v, n.Body)
+		if n.Body != nil {
+			Walk(v, n.Body)
+		}
+
 		Walk(v, n.Init)
 		Walk(v, n.Value)
 	case *CaseClause:
@@ -86,9 +95,18 @@ func Walk(v IVisitor, n INode) {
 	case *ThrowStmt:
 		Walk(v, n.Value)
 	case *TryStmt:
-		Walk(v, n.Body)
-		Walk(v, n.Catch)
-		Walk(v, n.Finally)
+		if n.Body != nil {
+			Walk(v, n.Body)
+		}
+
+		if n.Catch != nil {
+			Walk(v, n.Catch)
+		}
+
+		if n.Finally != nil {
+			Walk(v, n.Finally)
+		}
+
 		Walk(v, n.Binding)
 	case *DebuggerStmt:
 		return
@@ -122,7 +140,10 @@ func Walk(v IVisitor, n INode) {
 
 		Walk(v, n.Rest)
 	case *BindingObjectItem:
-		Walk(v, n.Key)
+		if n.Key != nil {
+			Walk(v, n.Key)
+		}
+
 		Walk(v, &n.Value)
 	case *BindingObject:
 		if n.List != nil {
@@ -131,7 +152,9 @@ func Walk(v IVisitor, n INode) {
 			}
 		}
 
-		Walk(v, n.Rest)
+		if n.Rest != nil {
+			Walk(v, n.Rest)
+		}
 	case *BindingElement:
 		Walk(v, n.Binding)
 		Walk(v, n.Default)
@@ -152,7 +175,10 @@ func Walk(v IVisitor, n INode) {
 	case *FuncDecl:
 		Walk(v, &n.Body)
 		Walk(v, &n.Params)
-		Walk(v, n.Name)
+
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
 	case *MethodDecl:
 		Walk(v, &n.Body)
 		Walk(v, &n.Params)
@@ -161,7 +187,10 @@ func Walk(v IVisitor, n INode) {
 		Walk(v, &n.Name)
 		Walk(v, n.Init)
 	case *ClassDecl:
-		Walk(v, n.Name)
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+
 		Walk(v, n.Extends)
 
 		if n.Definitions != nil {
@@ -186,7 +215,10 @@ func Walk(v IVisitor, n INode) {
 			}
 		}
 	case *Property:
-		Walk(v, n.Name)
+		if n.Name != nil {
+			Walk(v, n.Name)
+		}
+
 		Walk(v, n.Value)
 		Walk(v, n.Init)
 	case *ObjectExpr:
@@ -226,7 +258,10 @@ func Walk(v IVisitor, n INode) {
 			}
 		}
 	case *NewExpr:
-		Walk(v, n.Args)
+		if n.Args != nil {
+			Walk(v, n.Args)
+		}
+
 		Walk(v, n.X)
 	case *CallExpr:
 		Walk(v, &n.Args)

--- a/js/walk_test.go
+++ b/js/walk_test.go
@@ -42,3 +42,71 @@ func TestWalk(t *testing.T) {
 		test.String(t, ast.JS(), "if (true) { for (i = 0; i < 1; i++) { obj.y = i; }; }; ")
 	})
 }
+
+func TestWalkNilNode(t *testing.T) {
+	nodes := []INode{
+		&AST{},
+		&Var{},
+		&BlockStmt{},
+		&EmptyStmt{},
+		&ExprStmt{},
+		&IfStmt{},
+		&DoWhileStmt{},
+		&WhileStmt{},
+		&ForStmt{},
+		&ForInStmt{},
+		&ForOfStmt{},
+		&CaseClause{},
+		&SwitchStmt{},
+		&BranchStmt{},
+		&ReturnStmt{},
+		&WithStmt{},
+		&LabelledStmt{},
+		&ThrowStmt{},
+		&TryStmt{},
+		&DebuggerStmt{},
+		&Alias{},
+		&ImportStmt{},
+		&ExportStmt{},
+		&DirectivePrologueStmt{},
+		&PropertyName{},
+		&BindingArray{},
+		&BindingObjectItem{},
+		&BindingObject{},
+		&BindingElement{},
+		&VarDecl{},
+		&Params{},
+		&FuncDecl{},
+		&MethodDecl{},
+		&FieldDefinition{},
+		&ClassDecl{},
+		&LiteralExpr{},
+		&Element{},
+		&ArrayExpr{},
+		&Property{},
+		&ObjectExpr{},
+		&TemplatePart{},
+		&TemplateExpr{},
+		&GroupExpr{},
+		&IndexExpr{},
+		&DotExpr{},
+		&NewTargetExpr{},
+		&ImportMetaExpr{},
+		&Arg{},
+		&Args{},
+		&NewExpr{},
+		&CallExpr{},
+		&OptChainExpr{},
+		&UnaryExpr{},
+		&BinaryExpr{},
+		&CondExpr{},
+		&YieldExpr{},
+		&ArrowFunc{},
+	}
+
+	t.Run("TestWalkNilNode", func(t *testing.T) {
+		for _, n := range nodes {
+			Walk(&walker{}, n)
+		}
+	})
+}


### PR DESCRIPTION
When we removed the double nil check in https://github.com/tdewolff/parse/commit/7116c70a8e8b5751f85475f8147cd5747c0f5fe1, we accidentally reintroduced panics into the AST walker. 

This happened because the following line can evaluate to false when the interface, but not the underlying data structure, is nil:
https://github.com/karelorigin/parse/blob/803d5a5faa635f7ca194fd311d05ce600e052ee4/js/walk.go#L13 

You can find some examples here: https://yourbasic.org/golang/gotcha-why-nil-error-not-equal-nil/

I also added the relevant unit tests to prevent it from popping up again in the future.