### PR TITLE
JS: fix walk ClassDecl typo

### DIFF
--- a/js/walk.go
+++ b/js/walk.go
@@ -200,8 +200,8 @@ func Walk(v IVisitor, n INode) {
 		}
 
 		if n.Methods != nil {
-			for i := 0; i < len(n.Definitions); i++ {
-				Walk(v, &n.Definitions[i])
+			for i := 0; i < len(n.Methods); i++ {
+				Walk(v, n.Methods[i])
 			}
 		}
 	case *LiteralExpr:


### PR DESCRIPTION
This fixes a small typo, so it's possible to traverse the methods as well