### PR TITLE
JS: Fix EmptyStmt Semicolon duplication when converts the AST to JS

### DIFF
--- a/js/ast.go
+++ b/js/ast.go
@@ -384,7 +384,9 @@ func (n BlockStmt) JS() string {
 		s += "{ "
 	}
 	for _, item := range n.List {
-		s += item.JS() + "; "
+		if _, isEmpty := item.(*EmptyStmt); !isEmpty {
+			s += item.JS() + "; "
+		}
 	}
 	if n.Scope.Parent != nil {
 		s += "}"


### PR DESCRIPTION
When converting AST to Javascript, when finding an `EmptyStmt`, a semicolon is being added.

The problem with this is that a new AST generated from this original conversion will result in different output than the previous one.

The test below, in the current version, results in an error.

1. `a; ;` after 2 `.JS()` will be `a; ;; ;;`
![Screen Shot 2022-08-27 at 12 47 20](https://user-images.githubusercontent.com/675430/187038180-822e3194-0c5d-470d-8815-3eec9ce11940.png)

2. `function x() { let a = 33; ; }`  after 2 `.JS()` will be `function x() { let a = 33;  ;; ;; }`
![Screen Shot 2022-08-27 at 12 47 35](https://user-images.githubusercontent.com/675430/187038190-62ef1bf3-ad7a-4dce-bbdf-662e1c7084e4.png)


The fix just ignores when an item from a `BlockStmt` is an `EmptyStmt`

![Screen Shot 2022-08-27 at 12 52 10](https://user-images.githubusercontent.com/675430/187038424-58e08522-cc10-4575-b013-5766aa5455ce.png)


```go
func TestEmptyStmtToJs(t *testing.T) {
	var tests = []struct {
		input  string
		output string
	}{
		{"a; ;", "a; "},
		{"function x() { let a = 33; ; }", "function x () { let a = 33; }; "},
	}
	for _, tt := range tests {
		t.Run(tt.input, func(t *testing.T) {
			ast, err := Parse(parse.NewInputString(tt.input), Options{})
			if err != io.EOF {
				test.Error(t, err)
			}

			ast2, err := Parse(parse.NewInputString(ast.JS()), Options{})
			if err != io.EOF {
				test.Error(t, err)
			}
			test.String(t, ast2.JS(), tt.output)
		})
	}
}
```