### PR TITLE
JS: add ast JSWriteTo method

### DIFF
--- a/js/ast.go
+++ b/js/ast.go
@@ -2479,44 +2479,74 @@ func (n MethodDecl) JSWriteTo(w io.Writer) (i int64, err error) {
 	var wn int
 	var wn64 int64
 	if n.Static {
-		wn, err = w.Write([]byte(" static"))
+		wn, err = w.Write([]byte("static"))
 		i += int64(wn)
 		if err != nil {
 			return
 		}
 	}
 	if n.Async {
-		wn, err = w.Write([]byte(" async"))
+		if wn > 0 {
+			wn, err = w.Write([]byte(" "))
+			i += int64(wn)
+			if err != nil {
+				return
+			}
+		}
+		wn, err = w.Write([]byte("async"))
 		i += int64(wn)
 		if err != nil {
 			return
 		}
 	}
 	if n.Generator {
-		wn, err = w.Write([]byte(" *"))
+		if wn > 0 {
+			wn, err = w.Write([]byte(" "))
+			i += int64(wn)
+			if err != nil {
+				return
+			}
+		}
+		wn, err = w.Write([]byte("*"))
 		i += int64(wn)
 		if err != nil {
 			return
 		}
 	}
 	if n.Get {
-		wn, err = w.Write([]byte(" get"))
+		if wn > 0 {
+			wn, err = w.Write([]byte(" "))
+			i += int64(wn)
+			if err != nil {
+				return
+			}
+		}
+		wn, err = w.Write([]byte("get"))
 		i += int64(wn)
 		if err != nil {
 			return
 		}
 	}
 	if n.Set {
-		wn, err = w.Write([]byte(" set"))
+		if wn > 0 {
+			wn, err = w.Write([]byte(" "))
+			i += int64(wn)
+			if err != nil {
+				return
+			}
+		}
+		wn, err = w.Write([]byte("set"))
 		i += int64(wn)
 		if err != nil {
 			return
 		}
 	}
-	wn, err = w.Write([]byte(" "))
-	i += int64(wn)
-	if err != nil {
-		return
+	if wn > 0 {
+		wn, err = w.Write([]byte(" "))
+		i += int64(wn)
+		if err != nil {
+			return
+		}
 	}
 	wn64, err = n.Name.JSWriteTo(w)
 	i += wn64


### PR DESCRIPTION
I often edit ast, modify some data, and then convert ast back to js code, ast.JS() is too slow and takes up a lot of memory

Using buffers can greatly improve efficiency

```
BenchmarkJsAstJSWriteTo-2        10           194873291 ns/op      36253063 B/op    1031732 allocs/op
BenchmarkJsAstJS-2               10          1559868949 ns/op    2160659760 B/op    1057158 allocs/op
```

```go
// JSWriteTo
ast, _ := js.Parse(parse.NewInputBytes(body), js.Options{})
...
var buf bytes.Buffer
ast.JSWriteTo(&buf)

// JS
ast, _ := js.Parse(parse.NewInputBytes(body), js.Options{})
...
ast.JS()
```

If this is useful, consider this pr