### PR TITLE
Support CSS Nesting (resolve #92)

### DIFF
--- a/css/lex.go
+++ b/css/lex.go
@@ -140,6 +140,13 @@ type Lexer struct {
 	r *parse.Input
 }
 
+func CloneLexer(l *Lexer) *Lexer {
+	rr := parse.CloneInput(l.r)
+	return &Lexer{
+		r: rr,
+	}
+}
+
 // NewLexer returns a new Lexer for a given io.Reader.
 func NewLexer(r *parse.Input) *Lexer {
 	return &Lexer{

--- a/css/parse.go
+++ b/css/parse.go
@@ -264,10 +264,10 @@ func (p *Parser) parseDeclarationList() GrammarType {
 		pp.tt, pp.data = pp.popToken(false)
 	}
 
-	if isDeclaration && (p.tt == IdentToken || p.tt == DelimToken) {
-		return p.parseDeclaration()
-	} else {
+	if !isDeclaration {
 		return p.parseQualifiedRule()
+	} else if p.tt == IdentToken || p.tt == DelimToken {
+		return p.parseDeclaration()
 	}
 
 	// parse error

--- a/css/parse.go
+++ b/css/parse.go
@@ -27,8 +27,6 @@ const (
 	BeginRulesetGrammar
 	EndRulesetGrammar
 	DeclarationGrammar
-	BeginNestedRuleGrammar
-	EndNestedRuleGrammar
 	TokenGrammar
 	CustomPropertyGrammar
 )
@@ -58,10 +56,6 @@ func (tt GrammarType) String() string {
 		return "Token"
 	case CustomPropertyGrammar:
 		return "CustomProperty"
-	case BeginNestedRuleGrammar:
-		return "BeginNestedRule"
-	case EndNestedRuleGrammar:
-		return "EndNestedRule"
 	}
 	return "Invalid(" + strconv.Itoa(int(tt)) + ")"
 }
@@ -242,8 +236,8 @@ func (p *Parser) parseDeclarationList() GrammarType {
 	pp := p.CloneParser()
 	// peek until we find a colon or semicolon or data length is 1 and is a combinator ->
 	// not a child rule, but a declaration
-	isDeclaration := false
-	for {
+	isDeclaration := true
+	for pp.tt != ErrorToken {
 		if pp.tt == SemicolonToken || pp.tt == RightBraceToken {
 			isDeclaration = true
 			break

--- a/css/parse_test.go
+++ b/css/parse_test.go
@@ -39,6 +39,8 @@ func TestParse(t *testing.T) {
 		{false, "@media { @viewport ; }", "@media{@viewport;}"},
 		{false, "@keyframes 'diagonal-slide' {  from { left: 0; top: 0; } to { left: 100px; top: 100px; } }", "@keyframes 'diagonal-slide'{from{left:0;top:0;}to{left:100px;top:100px;}}"},
 		{false, "@keyframes movingbox{0%{left:90%;}50%{left:10%;}100%{left:90%;}}", "@keyframes movingbox{0%{left:90%;}50%{left:10%;}100%{left:90%;}}"},
+		{false, "a { &:hover { color: #f4a; } }", "a{&:hover{color:#f4a;}}"},
+		{false, ".foo { .bar > &:hover span { backgroud: orange } ; }", ".foo{.bar>&:hover span{backgroud:orange;}}"},
 		{false, ".foo { color: #fff;}", ".foo{color:#fff;}"},
 		{false, ".foo { ; _color: #fff;}", ".foo{_color:#fff;}"},
 		{false, "a { color: red; border: 0; }", "a{color:red;border:0;}"},
@@ -81,7 +83,7 @@ func TestParse(t *testing.T) {
 		{false, "[class*=\"column\"]+[class*=\"column\"]:last-child{a:b;}", "[class*=\"column\"]+[class*=\"column\"]:last-child{a:b;}"},
 		{false, "@media { @viewport }", "@media{@viewport;}"},
 		{false, "table { @unknown }", "table{@unknown;}"},
-		{false, "a{@media{width:70%;} b{width:60%;}}", "a{@media{ERROR(width:70%;})ERROR(b{width:60%;})}"},
+		{false, "a{@media{width:70%;} b{width:60%;}}", "a{@media{ERROR(width:70%;})b{width:60%;}}"},
 
 		// early endings
 		{false, "selector{", "selector{"},

--- a/input.go
+++ b/input.go
@@ -74,6 +74,15 @@ func NewInputBytes(b []byte) *Input {
 	return z
 }
 
+func CloneInput(z *Input) *Input {
+	return &Input{
+		buf:   append([]byte{}, z.buf...),
+		pos:   z.pos,
+		start: z.start,
+		err:   z.err,
+	}
+}
+
 // Restore restores the replaced byte past the end of the buffer by NULL.
 func (z *Input) Restore() {
 	if z.restore != nil {


### PR DESCRIPTION
It seems that there are no `p.Peek()`, so I clone the Parser every time it enters a QualifiedRuleset. Lookahead is necessary, since we cannot determine whether it is a declaration or a child rule:

```css
.a {
  div:hover {
    ...
  }
}

.a {
  prop:value
}
```

Decl is `<ident><colon><value>+`, but not vice versa. So we need to step until `<lbrace>`/a combinator (child rule) or `<semi>/<rbace>` (decl).


Also, the test case
```go
{false, "a{@media{width:70%;} b{width:60%;}}", "a{@media{ERROR(width:70%;})ERROR(b{width:60%;})}"},
```

should be all valid as Chrome supports empty media queries:

![css-test](https://github.com/user-attachments/assets/f7d8c469-1703-44d9-bf89-ceef673b1d43)
