### PR TITLE
Align IBinaryReader EOF with bytes.Reader

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -39,9 +39,11 @@ func (r *binaryReaderBytes) Bytes(b []byte, n, off int64) ([]byte, error) {
 	var err error
 	if off < 0 || n < 0 {
 		return nil, fmt.Errorf("bytes: invalid range %d--%d", off, off+n)
+	} else if n == 0 {
+		return nil, nil
 	} else if int64(len(r.data)) <= off {
 		return nil, io.EOF
-	} else if int64(len(r.data))-off <= n {
+	} else if int64(len(r.data))-off < n {
 		n = int64(len(r.data)) - off
 		err = io.EOF
 	}
@@ -79,6 +81,8 @@ func (r *binaryReaderReader) Len() int64 {
 func (r *binaryReaderReader) Bytes(b []byte, n, off int64) ([]byte, error) {
 	if off != r.pos {
 		return nil, errors.New("reader: does not implement io.Seeker or io.ReaderAt")
+	} else if n == 0 {
+		return nil, nil
 	} else if b == nil {
 		b = make([]byte, n)
 	}
@@ -92,9 +96,6 @@ func (r *binaryReaderReader) Bytes(b []byte, n, off int64) ([]byte, error) {
 		} else if m == 0 {
 			return b[:i], errors.New("reader: could not read all bytes")
 		}
-	}
-	if off+n == r.size {
-		return b, io.EOF
 	}
 	return b, nil
 }
@@ -123,6 +124,9 @@ func (r *binaryReaderSeeker) Len() int64 {
 }
 
 func (r *binaryReaderSeeker) Bytes(b []byte, n, off int64) ([]byte, error) {
+	if n == 0 {
+		return nil, nil
+	}
 	if b == nil {
 		b = make([]byte, n)
 	}
@@ -143,9 +147,6 @@ func (r *binaryReaderSeeker) Bytes(b []byte, n, off int64) ([]byte, error) {
 	}
 	r.mu.Unlock()
 
-	if off+n == r.size {
-		return b, io.EOF
-	}
 	return b, nil
 }
 
@@ -172,13 +173,14 @@ func (r *binaryReaderReaderAt) Len() int64 {
 }
 
 func (r *binaryReaderReaderAt) Bytes(b []byte, n, off int64) ([]byte, error) {
+	if n == 0 {
+		return nil, nil
+	}
 	if b == nil {
 		b = make([]byte, n)
 	}
 	if m, err := r.r.ReadAt(b, off); err != nil {
 		return b[:m], err
-	} else if off+int64(m) == r.size {
-		return b[:m], io.EOF
 	} else if int64(m) != n {
 		return b[:m], errors.New("reader: could not read all bytes")
 	}


### PR DESCRIPTION
All four IBinaryReader implementations currently return io.EOF as soon as a read lands exactly at the end of the buffer, even when the read itself was fully satisfied. This differs from how the standard library handles the same case:

- `bytes.Reader.Read` / `strings.Reader.Read` return `(n, nil)` on an exact-fit read and leave io.EOF for the next call.
- `bytes.Reader.ReadAt` / `strings.Reader.ReadAt` only attach io.EOF when the read is actually short (`n < len(b)`).
- `io.SectionReader` follows the same pattern and only returns EOF on the next call past the end.

This change adjusts the four implementations to match:

- Drops the `off+n == r.size` / `<= n` exact-fit EOF in binaryReaderBytes, binaryReaderReader, binaryReaderSeeker, and binaryReaderReaderAt. EOF is still returned for short reads, and a subsequent read past the end still returns io.EOF.
- Adds an early return for `n == 0`, so a zero-length read at end-of-buffer no longer surfaces as EOF.